### PR TITLE
Refactor lessons API: split service layer, tighten validation, session & rate-limiter improvements, and add endpoint tests

### DIFF
--- a/backend/src/controllers/lessonsController.js
+++ b/backend/src/controllers/lessonsController.js
@@ -1,234 +1,136 @@
+import {
+  createLessonForUser,
+  deleteLessonForUser,
+  listLessonsForUser,
+  recordLessonViewForUser,
+  setFavoriteForUser,
+} from '../services/lessonsService.js';
 
-import Lesson from '../models/lesson.js';
-import User from '../models/User.js';
-
-// Fonction utilitaire pour mettre à jour le favoris
-export async function updateFavorite(id, favorite) {
-    const mongoose = require('mongoose');
-    let lesson = null;
-    if (mongoose.Types.ObjectId.isValid(id)) {
-        lesson = await Lesson.findByIdAndUpdate(id, { favorite }, { new: true });
-    }
-    return lesson;
+function shapeLesson(lesson) {
+  return {
+    id: lesson._id?.toString?.() ?? lesson.id ?? '',
+    userId: lesson.userId?.toString?.() ?? '',
+    title: lesson.title?.toString?.() ?? '',
+    summary: lesson.summary?.toString?.() ?? '',
+    steps: Array.isArray(lesson.steps) ? lesson.steps.map((s) => s?.toString?.() ?? '') : [],
+    videoUrl: lesson.videoUrl?.toString?.() ?? '',
+    favorite: Boolean(lesson.favorite),
+    views: typeof lesson.views === 'number' ? lesson.views : 0,
+    createdAt: lesson.createdAt?.toISOString?.() ?? new Date().toISOString(),
+    updatedAt: lesson.updatedAt?.toISOString?.() ?? new Date().toISOString(),
+  };
 }
 
-/**
- * Create a lesson from chat data
- */
-export const createLesson = async (req, res) => {
-    try {
-        const { userId, title, steps, videoUrl, summary } = req.body;
-        if (!userId || !title || !steps || !videoUrl) {
-            return res.status(400).json({
-                error: "Missing required fields: userId, title, steps, videoUrl"
-            });
-        }
-        // Create lesson in MongoDB
-        const lesson = await Lesson.create({ userId, title, steps, videoUrl, summary });
-        // Link lesson to user's savedLessons
-        await User.findByIdAndUpdate(userId, { $push: { savedLessons: lesson._id } });
-        res.status(201).json(lesson);
-    } catch (error) {
-        console.error("Create lesson error:", error);
-        // Log full error object for debugging
-        try {
-            console.error("Full error:", JSON.stringify(error, Object.getOwnPropertyNames(error)));
-        } catch (e) {
-            console.error("Error stringification failed:", e);
-        }
-        res.status(500).json({
-            error: "Internal server error",
-            detail: error.message,
-            stack: error.stack,
-            name: error.name
-        });
+export async function createLesson(req, res) {
+  try {
+    const { title, steps, videoUrl, summary } = req.body || {};
+    const userId = req.userId;
+
+    if (!userId || typeof userId !== 'string' || userId.length < 3 || userId.length > 128) {
+      return res.status(400).json({ error: 'Invalid userId' });
     }
-};
 
-/**
- * Generate a lesson from a query
- */
-export const generateLesson = async (req, res) => {
-    try {
-        const { query, userId } = req.body;
-
-        if (!query || !userId) {
-            return res.status(400).json({
-                error: "Missing required fields: query, userId"
-            });
-        }
-
-        // Check for mock mode
-        const MOCK_MODE = (process.env.MOCK_MODE || "true") === "true";
-        if (MOCK_MODE) {
-            const lesson = {
-                id: generateId(),
-                userId,
-                title: `Leçon: ${query}`,
-                steps: [
-                    "Étape 1: Préparez vos matériaux",
-                    "Étape 2: Suivez les instructions",
-                    "Étape 3: Vérifiez votre travail",
-                    "Étape 4: Nettoyez l'espace de travail"
-                ],
-                videoUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                summary: "Cette leçon vous guide à travers les étapes de base.",
-                favorite: false,
-                views: 0,
-                createdAt: new Date().toISOString(),
-                updatedAt: new Date().toISOString()
-            };
-
-            lessons.push(lesson);
-            return res.status(201).json(lesson);
-        }
-
-        // Real implementation would:
-        // 1. Reformulate query
-        // 2. Search YouTube
-        // 3. Generate summary with Gemini
-        // 4. Create lesson
-
-        // For now, return mock data
-        const lesson = {
-            id: generateId(),
-            userId,
-            title: `Leçon générée: ${query}`,
-            steps: ["Contenu en cours de génération..."],
-            videoUrl: "https://example.com/video",
-            summary: null,
-            favorite: false,
-            views: 0,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString()
-        };
-
-        lessons.push(lesson);
-        res.status(201).json(lesson);
-    } catch (error) {
-        console.error("Generate lesson error:", error);
-        res.status(500).json({
-            error: "Internal server error",
-            detail: error.message
-        });
+    const isAnon = userId.startsWith('anon_');
+    const isNumeric = /^[0-9]+$/.test(userId);
+    const isAlphaNum = /^[a-zA-Z0-9_-]+$/.test(userId);
+    if (!(isAnon || isNumeric || isAlphaNum)) {
+      return res.status(400).json({ error: 'userId must be anon_, numeric, or alphanum' });
     }
-};
 
-/**
- * List lessons for a user
- */
-export const listLessons = async (req, res) => {
-    try {
-        const { userId, favorite, sort = 'createdAt', order = 'desc', limit = 50, offset = 0 } = req.query;
-        if (!userId) {
-            return res.status(400).json({
-                error: "Missing required parameter: userId"
-            });
-        }
-        const mongoose = require('mongoose');
-        let lessons = [];
-        if (mongoose.Types.ObjectId.isValid(userId)) {
-            // Registered user: get savedLessons
-            const user = await User.findById(userId).populate({
-                path: 'savedLessons',
-                match: favorite !== undefined ? { favorite: favorite === 'true' } : {},
-                options: {
-                    sort: { [sort]: order === 'asc' ? 1 : -1 },
-                    limit: parseInt(limit) || 50,
-                    skip: parseInt(offset) || 0
-                }
-            });
-            if (!user) {
-                return res.status(404).json({ error: 'Utilisateur non trouvé.' });
-            }
-            lessons = user.savedLessons || [];
-        } else {
-            // Guest/anonymous: get lessons by userId field
-            lessons = await Lesson.find({ userId }).sort({ [sort]: order === 'asc' ? 1 : -1 }).limit(parseInt(limit) || 50).skip(parseInt(offset) || 0);
-            if (favorite !== undefined) {
-                lessons = lessons.filter(l => !!l.favorite === (favorite === 'true'));
-            }
-        }
-        res.json({
-            items: lessons,
-            total: lessons.length,
-            limit: parseInt(limit) || 50,
-            offset: parseInt(offset) || 0
-        });
-    } catch (error) {
-        console.error("List lessons error:", error);
-        res.status(500).json({
-            error: "Internal server error",
-            detail: error.message
-        });
+    if (!title || typeof title !== 'string' || title.length < 2 || title.length > 120) {
+      return res.status(400).json({ error: 'Title must be 2-120 chars' });
     }
-};
 
-/**
- * Set favorite status for a lesson
- */
-export const setFavorite = async (req, res) => {
-    try {
-        const { id } = req.params;
-        const { favorite } = req.body;
-        if (favorite === undefined) {
-            return res.status(400).json({
-                error: "Missing required field: favorite"
-            });
-        }
-        const mongoose = require('mongoose');
-        let lesson = null;
-        if (mongoose.Types.ObjectId.isValid(id)) {
-            lesson = await Lesson.findByIdAndUpdate(id, { favorite }, { new: true });
-        }
-        // Always return success, even for guest/invalid ids
-        res.json({ ok: true, lesson });
-    } catch (error) {
-        console.error("Set favorite error:", error);
-        res.json({ ok: true });
+    if (!videoUrl || typeof videoUrl !== 'string' || !/^https?:\/\/.{8,}/.test(videoUrl)) {
+      return res.status(400).json({ error: 'Invalid videoUrl' });
     }
-};
 
-/**
- * Record a view for a lesson
- */
-export const recordView = async (req, res) => {
-    try {
-        const { id } = req.params;
-        const lesson = await Lesson.findByIdAndUpdate(id, {
-            $inc: { views: 1 },
-            lastViewedAt: new Date(),
-            updatedAt: new Date()
-        }, { new: true });
-        if (!lesson) {
-            return res.status(404).json({ error: "Lesson not found" });
-        }
-        res.json(lesson);
-    } catch (error) {
-        console.error("Record view error:", error);
-        res.status(500).json({
-            error: "Internal server error",
-            detail: error.message
-        });
+    if (!Array.isArray(steps) || steps.length === 0 || steps.length > 20 || !steps.every((s) => typeof s === 'string' && s.length > 1 && s.length < 200)) {
+      return res.status(400).json({ error: 'steps[] must be 1-20 non-empty strings, each 2-200 chars' });
     }
-};
 
-/**
- * Delete a lesson
- */
-export const deleteLesson = async (req, res) => {
-    try {
-        const { id } = req.params;
-        const mongoose = require('mongoose');
-        // Only delete from MongoDB if id is a valid ObjectId
-        if (mongoose.Types.ObjectId.isValid(id)) {
-            await Lesson.findByIdAndDelete(id);
-            await User.updateMany({}, { $pull: { savedLessons: id } });
-        }
-        // Always return success, even for guest/invalid ids
-        res.json({ ok: true });
-    } catch (error) {
-        console.error("Delete lesson error:", error);
-        res.json({ ok: true });
-    }
-};
+    const lesson = await createLessonForUser({ userId, title, steps, videoUrl, summary });
+    return res.json(shapeLesson(lesson));
+  } catch (e) {
+    return res.status(500).json({ error: 'Failed to save lesson', detail: 'Internal error' });
+  }
+}
+
+export async function deleteLesson(req, res) {
+  const id = String(req.params.id || '').trim();
+  if (!id) return res.status(400).json({ error: 'id is required' });
+
+  try {
+    const result = await deleteLessonForUser({ lessonId: id, userId: req.userId });
+    if (result.invalidId) return res.status(400).json({ error: 'Invalid lesson id' });
+    if (result.deletedCount === 0) return res.status(404).json({ error: 'Lesson not found' });
+
+    return res.json({ deleted: true, id });
+  } catch (e) {
+    return res.status(500).json({ error: 'Failed to delete lesson', detail: e?.message || 'Unknown error' });
+  }
+}
+
+export async function setFavorite(req, res) {
+  const id = String(req.params.id || '').trim();
+  const favorite = !!req.body?.favorite;
+  if (!id) return res.status(400).json({ error: 'id is required' });
+
+  try {
+    const updated = await setFavoriteForUser({ lessonId: id, userId: req.userId, favorite });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    return res.json({ ok: true, lesson: shapeLesson(updated) });
+  } catch (e) {
+    return res.status(500).json({ error: 'Failed to update favorite', detail: e?.message || 'Unknown error' });
+  }
+}
+
+export async function recordView(req, res) {
+  const id = String(req.params.id || '').trim();
+  if (!id) return res.status(400).json({ error: 'id is required' });
+
+  try {
+    const updated = await recordLessonViewForUser({ lessonId: id, userId: req.userId });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    return res.json(shapeLesson(updated));
+  } catch (e) {
+    return res.status(500).json({ error: 'Failed to record view', detail: e?.message || 'Unknown error' });
+  }
+}
+
+export async function listLessons(req, res) {
+  const userId = req.userId;
+  if (!userId) return res.status(400).json({ error: 'userId is required' });
+
+  const favorite = req.query.favorite === undefined ? undefined : String(req.query.favorite).toLowerCase() === 'true';
+  const sortBy = ['createdAt', 'lastViewedAt', 'views'].includes(String(req.query.sort || '')) ? String(req.query.sort) : 'createdAt';
+  const order = String(req.query.order || 'desc').toLowerCase() === 'asc' ? 1 : -1;
+  const limit = Math.min(100, Math.max(1, parseInt(String(req.query.limit || '50'), 10)));
+  const offset = Math.max(0, parseInt(String(req.query.offset || '0'), 10));
+
+  try {
+    const items = await listLessonsForUser({ userId, favorite, sortBy, order, limit, offset });
+    const shapedItems = items.map((lesson) => ({
+      ...shapeLesson(lesson),
+      progress: lesson.progress || 0,
+      reminder: lesson.reminder || null,
+      guestPrompt: (!req.isAuthenticated?.() && !req.user)
+        ? 'Save progress or unlock premium features by signing in.'
+        : undefined,
+    }));
+
+    const suggestedActions = shapedItems.length === 0 ? [
+      { label: 'Search for a lesson', action: '/api/search' },
+      { label: 'Request help', action: '/support' },
+    ] : undefined;
+
+    return res.json({ items: shapedItems, total: shapedItems.length, suggestedActions });
+  } catch (e) {
+    return res.status(500).json({
+      error: 'Failed to list lessons', detail: e?.message || 'Unknown error', suggestedActions: [
+        { label: 'Retry', action: '/api/lessons' },
+        { label: 'Request help', action: '/support' },
+      ],
+    });
+  }
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,83 +1,27 @@
 // import { deleteLesson } from "./utils/persistence.js";
 // Deprecated persistence import removed. Use Mongoose models instead.
-import { OAuth2Client } from 'google-auth-library';
-import { pathToFileURL } from "url";
+import { randomBytes } from 'crypto';
+import { pathToFileURL } from 'url';
 
-import axios from "axios";
-import cors from "cors";
-import dotenv from "dotenv";
-import express from "express";
-import morgan from "morgan";
-// Avoid importing yt-search at module load on Node<20 to prevent undici File init crash
-
-import { searchYouTube as originalSearchYouTube } from "./services/youtube.js";
-import { getTranscript } from "./services/transcript.js";
-import { getChapters, extractDesiredChapters } from "./services/chapters.js";
-
-
-import { userIdMiddleware } from "./utils/userIdMiddleware.js";
-import passport from "./utils/passportGoogle.js";
-import { requireJwtAuth, requireJwtAuthOrGoogle } from "./utils/jwtAuth.js";
-// Import requireAuth middleware from this file
-// (already defined above)
-import session from "express-session";
-import userRouter from './routes/user.js';
+import axios from 'axios';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import express from 'express';
+import session from 'express-session';
 import mongoose from 'mongoose';
+import morgan from 'morgan';
 
-const googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
+import lessonsRouter from './routes/lessons.js';
+import userRouter from './routes/user.js';
+import { getChapters, extractDesiredChapters } from './services/chapters.js';
+import { getTranscript } from './services/transcript.js';
+import { searchYouTube as originalSearchYouTube } from './services/youtube.js';
+import { requireJwtAuthOrGoogle } from './utils/jwtAuth.js';
+import passport from './utils/passportGoogle.js';
+import { userIdMiddleware } from './utils/userIdMiddleware.js';
 
-// Middleware pour exiger une authentification Google ou un token Google
-async function requireAuth(req, res, next) {
-  // Logging of authorization header removed for security.
-  // Vérifie d'abord la session Passport
-  if (req.isAuthenticated?.() && req.user) {
-    return next();
-  }
-
-  // Vérifie le token Google envoyé en header
-  const authHeader = req.headers.authorization;
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    const token = authHeader.split(' ')[1];
-    try {
-      const ticket = await googleClient.verifyIdToken({
-        idToken: token,
-        audience: process.env.GOOGLE_CLIENT_ID,
-      });
-      const payload = ticket.getPayload();
-      if (payload && payload.sub) {
-        // Vérifie si l'utilisateur existe dans la BDD
-        const User = (await import('./models/User.js')).default;
-        let user = await User.findOne({ email: payload.email });
-        if (!user) {
-          // Crée automatiquement un compte utilisateur Google
-          user = new User({
-            email: payload.email,
-            password: '', // pas de mot de passe pour Google
-            favorites: [],
-            history: [],
-            savedLessons: []
-          });
-          await user.save();
-        }
-        req.user = {
-          id: user._id,
-          email: user.email,
-          displayName: payload.name,
-          photo: payload.picture,
-          provider: 'google',
-        };
-        return next();
-      }
-    } catch (err) {
-      // Token invalide
-      return res.status(401).json({ error: 'Invalid Google token', detail: err.message });
-    }
-  }
-
-  // Sinon, refuse
-  res.status(401).json({ error: 'Authentication required' });
-}
-
+// Avoid importing yt-search at module load on Node<20 to prevent undici File init crash
+const dynamicImport = (moduleName) => Function('m', 'return import(m)')(moduleName);
 
 dotenv.config({ quiet: true });
 
@@ -93,12 +37,53 @@ app.use(cors({
   credentials: true
 }));
 app.use(express.json());
-// Simple rate limiter for expensive endpoints
+// Rate limiter with Redis support (distributed) and in-memory fallback
 const rateLimit = {};
-function simpleRateLimit(key, maxPerMinute = 30) {
+const REDIS_URL = process.env.REDIS_URL;
+let redisClient = null;
+let redisReady = false;
+
+async function initRedisRateLimiter() {
+  if (!REDIS_URL || process.env.NODE_ENV === 'test' || redisReady || redisClient) return;
+  try {
+    const { createClient } = await dynamicImport('redis');
+    redisClient = createClient({ url: REDIS_URL });
+    redisClient.on('error', (err) => {
+      redisReady = false;
+      console.warn('Redis rate limiter unavailable:', err?.message || err);
+    });
+    await redisClient.connect();
+    redisReady = true;
+  } catch (err) {
+    redisClient = null;
+    redisReady = false;
+    if (process.env.NODE_ENV !== 'test') {
+      console.warn('Redis rate limiter disabled, fallback to memory:', err?.message || err);
+    }
+  }
+}
+
+await initRedisRateLimiter();
+
+async function simpleRateLimit(key, maxPerMinute = 30) {
+  if (redisReady && redisClient) {
+    try {
+      const bucket = Math.floor(Date.now() / 60000);
+      const redisKey = `ratelimit:${key}:${bucket}`;
+      const current = await redisClient.incr(redisKey);
+      if (current === 1) {
+        await redisClient.expire(redisKey, 60);
+      }
+      return current <= maxPerMinute;
+    } catch (err) {
+      redisReady = false;
+      console.warn('Redis rate limiting failed, using memory fallback:', err?.message || err);
+    }
+  }
+
   const now = Date.now();
   if (!rateLimit[key]) rateLimit[key] = [];
-  rateLimit[key] = rateLimit[key].filter(ts => now - ts < 60000);
+  rateLimit[key] = rateLimit[key].filter((ts) => now - ts < 60000);
   if (rateLimit[key].length >= maxPerMinute) return false;
   rateLimit[key].push(now);
   return true;
@@ -106,12 +91,36 @@ function simpleRateLimit(key, maxPerMinute = 30) {
 // Route GET /api/lessons accessible sans requireAuth
 // Removed duplicate /api/lessons route. Only the protected version remains below.
 // Session pour Passport
-app.use(session({
+const sessionConfig = {
+  name: 'hackit.sid',
   secret: process.env.SESSION_SECRET || "dev_secret",
   resave: false,
   saveUninitialized: false,
-  cookie: { httpOnly: true, sameSite: "lax", secure: process.env.NODE_ENV === "production", maxAge: 1000 * 3600 * 24 * 365 }
-}));
+  rolling: process.env.NODE_ENV === 'production',
+  cookie: {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 1000 * 3600 * 24 * 30,
+  },
+};
+
+const sessionStoreMongoUrl = process.env.SESSION_STORE_MONGO_URL || process.env.MONGODB_URI;
+if (process.env.NODE_ENV === 'production' && sessionStoreMongoUrl) {
+  try {
+    const mongoStoreModule = await dynamicImport('connect-mongo');
+    const MongoStore = mongoStoreModule.default;
+    sessionConfig.store = MongoStore.create({
+      mongoUrl: sessionStoreMongoUrl,
+      ttl: 60 * 60 * 24 * 30,
+      autoRemove: 'native',
+    });
+  } catch (err) {
+    console.warn('External session store unavailable, falling back to memory store:', err?.message || err);
+  }
+}
+
+app.use(session(sessionConfig));
 app.use(passport.initialize());
 app.use(passport.session());
 // Enable concise logging in all non-test environments
@@ -119,30 +128,36 @@ if (process.env.NODE_ENV && process.env.NODE_ENV !== "test") {
   app.use(morgan("dev"));
 }
 // ============ AUTHENTIFICATION GOOGLE ============
-// Lance le flow OAuth Google
-app.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
-
-// Callback Google OAuth
-app.get('/auth/google/callback',
-  passport.authenticate('google', { failureRedirect: '/' }),
-  (req, res) => {
-    // Redirige vers le frontend avec le userId en paramètre (à adapter selon l'URL du frontend)
-    const userId = req.user?.id;
-    res.redirect(`/auth-success?userId=${userId}`);
-  }
-);
-// DELETE /api/lessons/:id
-app.delete("/api/lessons/:id", requireJwtAuthOrGoogle, userIdMiddleware, async (req, res) => {
-  const id = String(req.params.id || '').trim();
-  if (!id) return res.status(400).json({ error: 'id is required' });
-  try {
-    await deleteLesson(id);
-    return res.json({ deleted: true, id });
-  } catch (e) {
-    return res.status(500).json({ error: 'Failed to delete lesson', detail: e?.message || 'Unknown error' });
-  }
+// Lance le flow OAuth Google (CSRF state token)
+app.get('/auth/google', (req, res, next) => {
+  const state = randomBytes(24).toString('hex');
+  req.session.oauthState = state;
+  return passport.authenticate('google', { scope: ['profile', 'email'], state })(req, res, next);
 });
 
+// Callback Google OAuth + state validation + session rotation
+app.get('/auth/google/callback',
+  (req, res, next) => {
+    const expectedState = req.session?.oauthState;
+    if (req.session) delete req.session.oauthState;
+    if (!expectedState || req.query.state !== expectedState) {
+      return res.status(403).json({ error: 'Invalid OAuth state' });
+    }
+    return next();
+  },
+  passport.authenticate('google', { failureRedirect: '/' }),
+  (req, res, next) => {
+    const authenticatedUser = req.user;
+    req.session.regenerate((sessionErr) => {
+      if (sessionErr) return next(sessionErr);
+      req.login(authenticatedUser, (loginErr) => {
+        if (loginErr) return next(loginErr);
+        const userId = authenticatedUser?.id;
+        return res.redirect(`/auth-success?userId=${userId}`);
+      });
+    });
+  }
+);
 // Endpoint pour récupérer l'utilisateur authentifié
 app.get('/api/me', (req, res) => {
   if (req.isAuthenticated?.() && req.user) {
@@ -405,7 +420,7 @@ app.get("/health/extended", (_req, res) => {
 app.post("/api/search", async (req, res) => {
   // Rate limit by IP
   const ip = req.ip || req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-  if (!simpleRateLimit(`search:${ip}`, 20)) {
+  if (!(await simpleRateLimit(`search:${ip}`, 20))) {
     return res.status(429).json({ error: 'Too many requests, slow down.' });
   }
   const { query } = req.body;
@@ -417,7 +432,9 @@ app.post("/api/search", async (req, res) => {
     const mock = makeMockResponse();
     const vid = extractYouTubeVideoId(mock.videoUrl) || 'dQw4w9WgXcQ';
     const citations = await buildCitations({ videoId: vid, videoTitle: mock.title, videoUrl: mock.videoUrl, max: 3 });
-    return res.json({ ...mock, citations });
+    const desiredChapters = extractDesiredChapters(query);
+    const chapters = (await getChapters(vid, mock.title, { desired: desiredChapters })).chapters;
+    return res.json({ ...mock, citations, chapters });
   }
 
   try {
@@ -453,7 +470,6 @@ app.post("/api/search", async (req, res) => {
       const video = await searchYouTube(searchTerm);
       videoTitle = video.title;
       videoUrl = video.url;
-      videoId = video.videoId || extractYouTubeVideoId(video.url);
       source = video.source || (process.env.YT_API_KEY ? "youtube-api" : "yt-search-fallback");
     } catch (videoErr) {
       console.warn("Video search failed:", videoErr.message);
@@ -530,7 +546,7 @@ app.post("/api/search", async (req, res) => {
 app.get("/api/search/stream", async (req, res) => {
   // Rate limit by IP
   const ip = req.ip || req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-  if (!simpleRateLimit(`stream:${ip}`, 10)) {
+  if (!(await simpleRateLimit(`stream:${ip}`, 10))) {
     return res.status(429).json({ error: 'Too many requests, slow down.' });
   }
   const query = String(req.query.query || "").trim();
@@ -612,8 +628,7 @@ app.get("/api/search/stream", async (req, res) => {
         const video = await searchYouTube(searchTerm);
         videoTitle = video.title;
         videoUrl = video.url;
-        videoId = video.videoId || extractYouTubeVideoId(video.url);
-        source = video.source || (process.env.YT_API_KEY ? "youtube-api" : "yt-search-fallback");
+          source = video.source || (process.env.YT_API_KEY ? "youtube-api" : "yt-search-fallback");
       } catch (videoErr) {
         if ((process.env.ALLOW_FALLBACK || "true") === "true") {
           const mock = makeMockResponse();
@@ -733,74 +748,20 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   });
 }
 
-// Connect to MongoDB
-mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/hackit', {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-});
-
-mongoose.connection.on('connected', () => {
-  console.log('MongoDB connected');
-});
-mongoose.connection.on('error', (err) => {
-  console.error('MongoDB connection error:', err);
-});
+// Connect to MongoDB (skip in tests to avoid external dependency requirement)
+const shouldConnectMongo = process.env.NODE_ENV !== 'test';
+if (shouldConnectMongo) {
+  const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/hackit';
+  mongoose.connect(mongoUri)
+    .then(() => {
+      console.log('MongoDB connected');
+    })
+    .catch((err) => {
+      console.error('MongoDB connection error:', err);
+    });
+}
 
 // ============ LESSON GENERATION & PERSISTENCE ============
-// POST /api/lessons { title, steps[], videoUrl, summary? } (userId via middleware)
-app.post("/api/lessons", requireJwtAuthOrGoogle, userIdMiddleware, async (req, res) => {
-  // Only log userId, not full headers
-  console.log('[POST /api/lessons] userId:', req.userId);
-  try {
-    const { title, steps, videoUrl, summary } = req.body || {};
-    const userId = req.userId;
-    // Advanced validation
-    if (!userId || typeof userId !== 'string' || userId.length < 3 || userId.length > 128) {
-      return res.status(400).json({ error: "Invalid userId" });
-    }
-    // Autoriser les userId anonymes ou numériques
-    const isAnon = userId.startsWith('anon_');
-    const isNumeric = /^[0-9]+$/.test(userId);
-    const isAlphaNum = /^[a-zA-Z0-9_\-]+$/.test(userId);
-    if (!(isAnon || isNumeric || isAlphaNum)) {
-      return res.status(400).json({ error: "userId must be anon_, numeric, or alphanum" });
-    }
-    if (!title || typeof title !== 'string' || title.length < 2 || title.length > 120) {
-      return res.status(400).json({ error: "Title must be 2-120 chars" });
-    }
-    if (!videoUrl || typeof videoUrl !== 'string' || !/^https?:\/\/.{8,}/.test(videoUrl)) {
-      return res.status(400).json({ error: "Invalid videoUrl" });
-    }
-    if (!Array.isArray(steps) || steps.length === 0 || steps.length > 20 || !steps.every(s => typeof s === 'string' && s.length > 1 && s.length < 200)) {
-      return res.status(400).json({ error: "steps[] must be 1-20 non-empty strings, each 2-200 chars" });
-    }
-    // Use Mongoose Lesson model directly
-    const Lesson = (await import('./models/lesson.js')).default;
-    const User = (await import('./models/User.js')).default;
-    const lesson = await Lesson.create({ userId, title, steps, videoUrl, summary });
-    // Only link lesson to user if userId is a valid ObjectId
-    const mongoose = (await import('mongoose')).default;
-    if (mongoose.Types.ObjectId.isValid(userId)) {
-      await User.findByIdAndUpdate(userId, { $push: { savedLessons: lesson._id } });
-    }
-    // Ensure all fields are non-null strings/arrays for frontend
-    return res.json({
-      id: lesson._id?.toString() ?? '',
-      userId: lesson.userId?.toString() ?? '',
-      title: lesson.title?.toString() ?? '',
-      summary: lesson.summary?.toString() ?? '',
-      steps: Array.isArray(lesson.steps) ? lesson.steps.map(s => s?.toString() ?? '') : [],
-      videoUrl: lesson.videoUrl?.toString() ?? '',
-      favorite: !!lesson.favorite,
-      views: typeof lesson.views === 'number' ? lesson.views : 0,
-      createdAt: lesson.createdAt?.toISOString?.() ?? new Date().toISOString(),
-      updatedAt: lesson.updatedAt?.toISOString?.() ?? new Date().toISOString(),
-    });
-  } catch (e) {
-    console.error('[POST /api/lessons] Internal error:', e?.message || e);
-    return res.status(500).json({ error: 'Failed to save lesson', detail: 'Internal error' });
-  }
-});
 // POST /api/generateLesson { query } (userId via middleware)
 app.post("/api/generateLesson", requireJwtAuthOrGoogle, userIdMiddleware, async (req, res) => {
   console.log('[POST /api/generateLesson] Authorization:', req.headers.authorization, 'userId:', req.userId);
@@ -830,17 +791,16 @@ app.post("/api/generateLesson", requireJwtAuthOrGoogle, userIdMiddleware, async 
       }
     }
 
-    let videoTitle, videoUrl, videoId;
+    let videoTitle, videoUrl;
     try {
       const video = await searchYouTube(searchTerm);
       videoTitle = video.title;
       videoUrl = video.url;
-      videoId = video.videoId || extractYouTubeVideoId(video.url);
     } catch (e) {
       console.warn("Video search (generateLesson) failed:", e.message);
       if ((process.env.ALLOW_FALLBACK || "true") === "true") {
         const mock = makeMockResponse();
-        videoTitle = mock.title; videoUrl = mock.videoUrl; videoId = extractYouTubeVideoId(videoUrl);
+        videoTitle = mock.title; videoUrl = mock.videoUrl;
       } else {
         throw e;
       }
@@ -895,89 +855,6 @@ app.post("/api/generateLesson", requireJwtAuthOrGoogle, userIdMiddleware, async 
   }
 });
 
-// PATCH /api/lessons/:id/favorite { favorite: true|false }
-import { updateFavorite } from './controllers/lessonsController.js';
-app.patch("/api/lessons/:id/favorite", requireJwtAuthOrGoogle, async (req, res) => {
-  console.log('[PATCH /api/lessons/:id/favorite] Authorization:', req.headers.authorization, 'userId:', req.userId);
-  const id = String(req.params.id || '').trim();
-  const favorite = !!req.body?.favorite;
-  if (!id || typeof id !== 'string') return res.status(400).json({ error: 'id is required' });
-  try {
-    const updated = await updateFavorite(id, favorite);
-    if (!updated) return res.status(404).json({ error: 'Not found' });
-    return res.json({ ok: true, lesson: updated });
-  } catch (e) {
-    console.error('[PATCH /api/lessons/:id/favorite] Internal error:', e?.message || e);
-    return res.status(500).json({ error: 'Failed to update favorite', detail: e?.message || 'Unknown error' });
-  }
-});
-
-// POST /api/lessons/:id/view -> record history entry (views++, lastViewedAt=now)
-app.post("/api/lessons/:id/view", requireJwtAuthOrGoogle, async (req, res) => {
-  console.log('[POST /api/lessons/:id/view] Authorization:', req.headers.authorization, 'userId:', req.userId);
-  const id = String(req.params.id || '').trim();
-  if (!id || typeof id !== 'string') return res.status(400).json({ error: 'id is required' });
-  try {
-    const updated = await recordView(id);
-    if (!updated) return res.status(404).json({ error: 'Not found' });
-    return res.json(updated);
-  } catch (e) {
-    console.error('[POST /api/lessons/:id/view] Internal error:', e?.message || e);
-    return res.status(500).json({ error: 'Failed to record view', detail: e?.message || 'Unknown error' });
-  }
-});
-
-// GET /api/lessons?favorite=true|false&sort=createdAt|lastViewedAt&order=desc|asc (userId via middleware)
-app.get("/api/lessons", requireJwtAuthOrGoogle, userIdMiddleware, async (req, res) => {
-  // Middleware to accept either JWT (login/password) or Google OAuth
-  function requireJwtAuthOrGoogle(req, res, next) {
-    // Try JWT first
-    const authHeader = req.headers.authorization;
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      const token = authHeader.split(' ')[1];
-      const { verifyToken } = require('./utils/jwtAuth.js');
-      const payload = verifyToken(token);
-      if (payload && payload.userId) {
-        req.userId = payload.userId;
-        req.jwtUser = payload;
-        return next();
-      }
-    }
-    // Fallback to Google OAuth
-    return requireAuth(req, res, next);
-  }
-  const userId = req.userId;
-  if (!userId) return res.status(400).json({ error: 'userId is required' });
-  const favorite = req.query.favorite === undefined ? undefined : String(req.query.favorite).toLowerCase() === 'true';
-  const sortBy = ['createdAt', 'lastViewedAt', 'views'].includes(String(req.query.sort || '')) ? String(req.query.sort) : 'createdAt';
-  const order = String(req.query.order || 'desc').toLowerCase() === 'asc' ? 'asc' : 'desc';
-  const limit = Math.min(100, Math.max(1, parseInt(String(req.query.limit || '50'), 10)));
-  const offset = Math.max(0, parseInt(String(req.query.offset || '0'), 10));
-  try {
-    let items = await listLessons({ userId, favorite, sortBy, order, limit, offset });
-    // Add progress/reminder fields for My Learning Journey pivot
-    items = items.map(lesson => ({
-      ...lesson,
-      progress: lesson.progress || 0, // Placeholder, to be implemented
-      reminder: lesson.reminder || null, // Placeholder, to be implemented
-      // Guest mode prompt
-      guestPrompt: (!req.isAuthenticated?.() && !req.user) ? 'Save progress or unlock premium features by signing in.' : undefined
-    }));
-    // Suggested actions for empty/error states
-    const suggestedActions = items.length === 0 ? [
-      { label: 'Search for a lesson', action: '/api/search' },
-      { label: 'Request help', action: '/support' }
-    ] : undefined;
-    return res.json({ items, total: items.length, suggestedActions });
-  } catch (e) {
-    return res.status(500).json({
-      error: 'Failed to list lessons', detail: e?.message || 'Unknown error', suggestedActions: [
-        { label: 'Retry', action: '/api/lessons' },
-        { label: 'Request help', action: '/support' }
-      ]
-    });
-  }
-});
-
-// Import and mount the user router on /api/users to expose /api/users/all endpoint.
+// Mount lessons and users routers.
+app.use('/api/lessons', lessonsRouter);
 app.use('/api/users', userRouter);

--- a/backend/src/routes/lessons.js
+++ b/backend/src/routes/lessons.js
@@ -1,31 +1,21 @@
-import express from "express";
+import express from 'express';
+
 import {
-    createLesson,
-    generateLesson,
-    listLessons,
-    setFavorite,
-    recordView,
-    deleteLesson
-} from "../controllers/lessonsController.js";
+  createLesson,
+  deleteLesson,
+  listLessons,
+  recordView,
+  setFavorite,
+} from '../controllers/lessonsController.js';
+import { requireJwtAuthOrGoogle } from '../utils/jwtAuth.js';
+import { userIdMiddleware } from '../utils/userIdMiddleware.js';
 
 const router = express.Router();
 
-// GET /api/lessons - List lessons for a user
-router.get("/", listLessons);
-
-// POST /api/lessons - Create a lesson from chat
-router.post("/", createLesson);
-
-// POST /api/generateLesson - Generate a lesson from query
-router.post("/generateLesson", generateLesson);
-
-// PATCH /api/lessons/:id/favorite - Set favorite status
-router.patch("/:id/favorite", setFavorite);
-
-// POST /api/lessons/:id/view - Record a view
-router.post("/:id/view", recordView);
-
-// DELETE /api/lessons/:id - Delete a lesson
-router.delete("/:id", deleteLesson);
+router.get('/', requireJwtAuthOrGoogle, userIdMiddleware, listLessons);
+router.post('/', requireJwtAuthOrGoogle, userIdMiddleware, createLesson);
+router.delete('/:id', requireJwtAuthOrGoogle, userIdMiddleware, deleteLesson);
+router.patch('/:id/favorite', requireJwtAuthOrGoogle, userIdMiddleware, setFavorite);
+router.post('/:id/view', requireJwtAuthOrGoogle, userIdMiddleware, recordView);
 
 export default router;

--- a/backend/src/services/lessonsService.js
+++ b/backend/src/services/lessonsService.js
@@ -1,0 +1,56 @@
+import mongoose from 'mongoose';
+
+import Lesson from '../models/lesson.js';
+import User from '../models/User.js';
+
+function isValidObjectId(id) {
+  return mongoose.Types.ObjectId.isValid(id);
+}
+
+export async function createLessonForUser({ userId, title, steps, videoUrl, summary }) {
+  const lesson = await Lesson.create({ userId, title, steps, videoUrl, summary });
+
+  if (isValidObjectId(userId)) {
+    await User.findByIdAndUpdate(userId, { $push: { savedLessons: lesson._id } });
+  }
+
+  return lesson;
+}
+
+export async function deleteLessonForUser({ lessonId, userId }) {
+  if (!isValidObjectId(lessonId)) {
+    return { invalidId: true, deletedCount: 0 };
+  }
+
+  const result = await Lesson.deleteOne({ _id: lessonId, userId });
+  return { invalidId: false, deletedCount: result.deletedCount || 0 };
+}
+
+export async function setFavoriteForUser({ lessonId, userId, favorite }) {
+  return await Lesson.findOneAndUpdate(
+    { _id: lessonId, userId },
+    { favorite, updatedAt: new Date() },
+    { new: true }
+  );
+}
+
+export async function recordLessonViewForUser({ lessonId, userId }) {
+  return await Lesson.findOneAndUpdate(
+    { _id: lessonId, userId },
+    { $inc: { views: 1 }, lastViewedAt: new Date(), updatedAt: new Date() },
+    { new: true }
+  );
+}
+
+export async function listLessonsForUser({ userId, favorite, sortBy, order, limit, offset }) {
+  const filter = { userId };
+  if (favorite !== undefined) {
+    filter.favorite = favorite;
+  }
+
+  return await Lesson.find(filter)
+    .sort({ [sortBy]: order })
+    .skip(offset)
+    .limit(limit)
+    .lean();
+}

--- a/backend/src/utils/passportGoogle.js
+++ b/backend/src/utils/passportGoogle.js
@@ -8,6 +8,10 @@ const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
 const GOOGLE_CALLBACK_URL = process.env.GOOGLE_CALLBACK_URL;
 
+const hasGoogleOAuthConfig = Boolean(
+    GOOGLE_CLIENT_ID && GOOGLE_CLIENT_SECRET && GOOGLE_CALLBACK_URL
+);
+
 passport.serializeUser((user, done) => {
     done(null, user);
 });
@@ -16,21 +20,25 @@ passport.deserializeUser((user, done) => {
     done(null, user);
 });
 
-passport.use(new GoogleStrategy({
-    clientID: GOOGLE_CLIENT_ID,
-    clientSecret: GOOGLE_CLIENT_SECRET,
-    callbackURL: GOOGLE_CALLBACK_URL,
-},
-    (accessToken, refreshToken, profile, done) => {
-        // Ici, on peut stocker/mettre à jour l'utilisateur en base si besoin
-        return done(null, {
-            id: profile.id,
-            displayName: profile.displayName,
-            email: profile.emails?.[0]?.value,
-            photo: profile.photos?.[0]?.value,
-            provider: 'google',
-        });
-    }
-));
+if (hasGoogleOAuthConfig) {
+    passport.use(new GoogleStrategy({
+        clientID: GOOGLE_CLIENT_ID,
+        clientSecret: GOOGLE_CLIENT_SECRET,
+        callbackURL: GOOGLE_CALLBACK_URL,
+    },
+        (accessToken, refreshToken, profile, done) => {
+            // Ici, on peut stocker/mettre à jour l'utilisateur en base si besoin
+            return done(null, {
+                id: profile.id,
+                displayName: profile.displayName,
+                email: profile.emails?.[0]?.value,
+                photo: profile.photos?.[0]?.value,
+                provider: 'google',
+            });
+        }
+    ));
+} else if (process.env.NODE_ENV !== 'test') {
+    console.warn('Google OAuth désactivé: variables GOOGLE_CLIENT_ID/SECRET/CALLBACK_URL manquantes.');
+}
 
 export default passport;

--- a/backend/src/utils/userIdMiddleware.js
+++ b/backend/src/utils/userIdMiddleware.js
@@ -1,35 +1,32 @@
-// Simple middleware to extract userId from header or query, or generate anonymous if missing
 import crypto from 'crypto';
 
 export function userIdMiddleware(req, res, next) {
-    console.log('[userIdMiddleware] headers:', req.headers);
-    console.log('[userIdMiddleware] query:', req.query);
-    console.log('[userIdMiddleware] body:', req.body);
-    let userId = req.header('x-user-id') || req.query.userId || req.body?.userId;
-    // Try to get from cookie if not present
-    if (!userId && req.headers.cookie) {
-        try {
-            const match = req.headers.cookie.match(/userId=([^;]+)/);
-            if (match) userId = match[1];
-        } catch (err) {
-            console.error('[userIdMiddleware] Cookie parse error:', err);
-        }
+  let userId = req.userId || req.header('x-user-id') || req.query.userId || req.body?.userId;
+
+  if (!userId && req.headers.cookie) {
+    try {
+      const match = req.headers.cookie.match(/userId=([^;]+)/);
+      if (match) userId = match[1];
+    } catch (_err) {
+      // ignore malformed cookie header
     }
-    if (!userId) {
-        userId = 'anon_' + (crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2));
-        req.isAnonymous = true;
-        // Set cookie for future requests (httpOnly=false for SPA access)
-        try {
-            if (res.cookie) {
-                res.cookie('userId', userId, { maxAge: 1000 * 3600 * 24 * 365, httpOnly: false, sameSite: 'lax' });
-            } else {
-                res.setHeader('Set-Cookie', `userId=${userId}; Path=/; Max-Age=31536000; SameSite=Lax`);
-            }
-        } catch (err) {
-            console.error('[userIdMiddleware] Set-Cookie error:', err);
-        }
+  }
+
+  if (!userId) {
+    userId = `anon_${crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)}`;
+    req.isAnonymous = true;
+
+    try {
+      if (res.cookie) {
+        res.cookie('userId', userId, { maxAge: 1000 * 3600 * 24 * 365, httpOnly: false, sameSite: 'lax' });
+      } else {
+        res.setHeader('Set-Cookie', `userId=${userId}; Path=/; Max-Age=31536000; SameSite=Lax`);
+      }
+    } catch (_err) {
+      // ignore cookie write failure
     }
-    console.log('[userIdMiddleware] resolved userId:', userId);
-    req.userId = userId;
-    next();
+  }
+
+  req.userId = String(userId);
+  next();
 }

--- a/backend/test/lessons.endpoints.test.js
+++ b/backend/test/lessons.endpoints.test.js
@@ -1,0 +1,207 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+import jwt from 'jsonwebtoken';
+
+process.env.NODE_ENV = 'test';
+
+const { createApp } = await import('../src/index.js');
+const Lesson = (await import('../src/models/lesson.js')).default;
+
+function startServer(app, port = 0) {
+  return new Promise((resolve) => {
+    const server = app.listen(port, () => {
+      const address = server.address();
+      resolve({ server, port: address.port });
+    });
+  });
+}
+
+function authHeaders(userId = '123456') {
+  const token = jwt.sign({ userId, email: 'test@example.com' }, process.env.JWT_SECRET || 'dev_jwt_secret', { expiresIn: '1h' });
+  return {
+    authorization: `Bearer ${token}`,
+    'x-user-id': userId,
+  };
+}
+
+function requestJson({ host = '127.0.0.1', port, path, method = 'GET', body, headers = {}, timeoutMs = 8000 }) {
+  const payload = body ? JSON.stringify(body) : '';
+  const requestHeaders = {
+    ...headers,
+  };
+
+  if (body) {
+    requestHeaders['content-type'] = 'application/json';
+    requestHeaders['content-length'] = Buffer.byteLength(payload);
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host, port, path, method, headers: requestHeaders }, (res) => {
+      let data = '';
+      res.setEncoding('utf8');
+      res.on('data', (c) => (data += c));
+      res.on('end', () => {
+        const parsed = data ? JSON.parse(data) : {};
+        resolve({ status: res.statusCode, data: parsed });
+      });
+    });
+
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => reject(new Error('timeout')));
+    if (body) req.write(payload);
+    req.end();
+  });
+}
+
+await test('DELETE /api/lessons/:id returns 400 for invalid id', async (t) => {
+  const app = createApp();
+  const { server, port } = await startServer(app);
+  t.after(() => server.close());
+
+  const res = await requestJson({
+    port,
+    path: '/api/lessons/not-an-objectid',
+    method: 'DELETE',
+    headers: authHeaders(),
+  });
+
+  assert.equal(res.status, 400);
+  assert.equal(res.data.error, 'Invalid lesson id');
+});
+
+await test('DELETE /api/lessons/:id returns 404 when lesson is not found', async (t) => {
+  const originalDeleteOne = Lesson.deleteOne;
+  Lesson.deleteOne = async () => ({ deletedCount: 0 });
+  t.after(() => {
+    Lesson.deleteOne = originalDeleteOne;
+  });
+
+  const app = createApp();
+  const { server, port } = await startServer(app);
+  t.after(() => server.close());
+
+  const res = await requestJson({
+    port,
+    path: '/api/lessons/507f1f77bcf86cd799439011',
+    method: 'DELETE',
+    headers: authHeaders(),
+  });
+
+  assert.equal(res.status, 404);
+  assert.equal(res.data.error, 'Lesson not found');
+});
+
+await test('PATCH /api/lessons/:id/favorite updates lesson favorite', async (t) => {
+  const originalFindOneAndUpdate = Lesson.findOneAndUpdate;
+  Lesson.findOneAndUpdate = async () => ({
+    _id: '507f1f77bcf86cd799439011',
+    userId: '123456',
+    title: 'Demo',
+    summary: '',
+    steps: ['Step 1'],
+    videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    favorite: true,
+    views: 0,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+  });
+  t.after(() => {
+    Lesson.findOneAndUpdate = originalFindOneAndUpdate;
+  });
+
+  const app = createApp();
+  const { server, port } = await startServer(app);
+  t.after(() => server.close());
+
+  const res = await requestJson({
+    port,
+    path: '/api/lessons/507f1f77bcf86cd799439011/favorite',
+    method: 'PATCH',
+    headers: authHeaders(),
+    body: { favorite: true },
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.data.ok, true);
+  assert.equal(res.data.lesson.favorite, true);
+});
+
+await test('POST /api/lessons/:id/view increments view and returns lesson', async (t) => {
+  const originalFindOneAndUpdate = Lesson.findOneAndUpdate;
+  Lesson.findOneAndUpdate = async () => ({
+    _id: '507f1f77bcf86cd799439011',
+    userId: '123456',
+    title: 'Demo',
+    summary: '',
+    steps: ['Step 1'],
+    videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    favorite: false,
+    views: 3,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+  });
+  t.after(() => {
+    Lesson.findOneAndUpdate = originalFindOneAndUpdate;
+  });
+
+  const app = createApp();
+  const { server, port } = await startServer(app);
+  t.after(() => server.close());
+
+  const res = await requestJson({
+    port,
+    path: '/api/lessons/507f1f77bcf86cd799439011/view',
+    method: 'POST',
+    headers: authHeaders(),
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.data.views, 3);
+});
+
+await test('GET /api/lessons supports pagination and sorting', async (t) => {
+  const originalFind = Lesson.find;
+  Lesson.find = () => ({
+    sort: () => ({
+      skip: () => ({
+        limit: () => ({
+          lean: async () => ([
+            {
+              _id: '507f1f77bcf86cd799439011',
+              userId: '123456',
+              title: 'Newest',
+              summary: 'S',
+              steps: ['A'],
+              videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+              favorite: true,
+              views: 10,
+              createdAt: new Date('2024-01-03T00:00:00.000Z'),
+              updatedAt: new Date('2024-01-03T00:00:00.000Z'),
+            },
+          ]),
+        }),
+      }),
+    }),
+  });
+  t.after(() => {
+    Lesson.find = originalFind;
+  });
+
+  const app = createApp();
+  const { server, port } = await startServer(app);
+  t.after(() => server.close());
+
+  const res = await requestJson({
+    port,
+    path: '/api/lessons?favorite=true&sort=views&order=desc&limit=1&offset=0',
+    method: 'GET',
+    headers: authHeaders(),
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.data.total, 1);
+  assert.equal(res.data.items[0].title, 'Newest');
+  assert.equal(res.data.items[0].favorite, true);
+});


### PR DESCRIPTION
### Motivation
- Consolidate lesson persistence logic into a service layer and simplify controllers to improve testability and separation of concerns.
- Harden request validation and shape responses to avoid nulls/unsafe types reaching the frontend.
- Improve runtime robustness for auth/session/rate-limiting (Redis optional, session store, OAuth state) and avoid loading fragile modules at import time.

### Description
- Moved lesson persistence operations into a new service `src/services/lessonsService.js` providing `createLessonForUser`, `deleteLessonForUser`, `listLessonsForUser`, `recordLessonViewForUser`, and `setFavoriteForUser`.
- Reworked `controllers/lessonsController.js` to use the service layer, add strict input validation, normalize responses via `shapeLesson`, and return consistent error payloads.
- Added routes in `src/routes/lessons.js` and mounted them in `src/index.js`, protecting endpoints with `requireJwtAuthOrGoogle` and `userIdMiddleware` as appropriate.
- Enhanced `src/index.js` with: dynamic imports to avoid module load issues, Redis-backed rate limiter with in-memory fallback, improved session configuration with optional `connect-mongo` store, OAuth state token and session rotation on Google callback, skipping MongoDB connect in `test` environment, and various small cleanups and logging improvements.
- Updated `src/utils/passportGoogle.js` to conditionally register the Google strategy when config is present and warn otherwise.
- Simplified and hardened `src/utils/userIdMiddleware.js` (stable anonymous id generation, cookie handling, no noisy logs).
- Added comprehensive endpoint tests in `backend/test/lessons.endpoints.test.js` covering delete, favorite patch, record view, and listing with pagination and sorting.

### Testing
- Ran the new endpoint test suite `backend/test/lessons.endpoints.test.js` under `NODE_ENV=test` using `node:test`, which starts the app via `createApp()` and exercises the lessons API; all tests passed.
- Tests use mocked model methods (`Lesson.findOneAndUpdate`, `Lesson.deleteOne`, `Lesson.find`, etc.) to isolate controller/service behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f3a7d444832f8a38e74a2b578ced)