### PR TITLE
Add Decision Pack endpoint and markdown formatter; include tests and docs

### DIFF
--- a/backend/src/routes/rooms.js
+++ b/backend/src/routes/rooms.js
@@ -210,6 +210,64 @@ function workspaceMilestoneSummary(milestone) {
     };
 }
 
+function formatDecisionPackMarkdown({ room, decisions, tasks, generatedAt }) {
+    const safeRoomName = String(room?.name || 'Channel').trim() || 'Channel';
+    const lines = [];
+    lines.push(`# Decision Pack — ${safeRoomName}`);
+    lines.push('');
+    lines.push(`Generated at: ${generatedAt.toISOString()}`);
+    lines.push('');
+    lines.push('## Decisions');
+    lines.push('');
+
+    if (!decisions.length) {
+        lines.push('- No decisions available yet.');
+    } else {
+        decisions.forEach((decision, index) => {
+            const decisionId = String(decision?._id || '').trim();
+            const title = String(decision?.title || '').trim() || `Decision ${index + 1}`;
+            const summary = String(decision?.summary || '').trim();
+            lines.push(`### ${index + 1}. ${title}`);
+            if (summary) lines.push(summary);
+            const linkedTasks = tasks.filter(
+                (task) => String(task?.decisionId || '') === decisionId
+            );
+            if (!linkedTasks.length) {
+                lines.push('- Tasks: none linked yet.');
+            } else {
+                lines.push('- Tasks:');
+                linkedTasks.forEach((task) => {
+                    const taskTitle = String(task?.title || '').trim() || 'Untitled task';
+                    const ownerName = String(task?.ownerName || '').trim();
+                    const dueDate = task?.dueDate ? new Date(task.dueDate).toISOString().slice(0, 10) : '';
+                    const suffix = [ownerName ? `owner: ${ownerName}` : '', dueDate ? `due: ${dueDate}` : '']
+                        .filter(Boolean)
+                        .join(', ');
+                    lines.push(`  - ${taskTitle}${suffix ? ` (${suffix})` : ''}`);
+                });
+            }
+            lines.push('');
+        });
+    }
+
+    lines.push('## Open Tasks (without decision link)');
+    lines.push('');
+    const unlinkedTasks = tasks.filter((task) => !task?.decisionId);
+    if (!unlinkedTasks.length) {
+        lines.push('- None.');
+    } else {
+        unlinkedTasks.forEach((task) => {
+            lines.push(`- ${String(task?.title || 'Untitled task').trim()}`);
+        });
+    }
+    lines.push('');
+    lines.push('## Next Review');
+    lines.push('');
+    lines.push('- Validate owners and deadlines for all critical tasks.');
+    lines.push('- Confirm decision status in the next channel review.');
+    return lines.join('\n');
+}
+
 function extractJsonObject(text) {
     const raw = String(text || '').trim();
     if (!raw) return null;
@@ -1710,6 +1768,56 @@ router.post('/:id/decisions/:decisionId/convert', validateBody(validateConvertDe
         res.status(201).json({
             decision: workspaceDecisionSummary(decision),
             tasks: createdTasks.map((task) => workspaceTaskSummary(task)),
+        });
+    } catch (err) {
+        next(err);
+    }
+});
+
+router.get('/:id/decision-pack', async (req, res, next) => {
+    try {
+        const room = await loadRoomOr404(req.params.id, res);
+        if (!room) return;
+        if (!isRoomMember(room, req.userId)) {
+            return res.status(403).json({ error: 'Not a member of this room' });
+        }
+
+        const limit = Math.max(1, Math.min(50, Number.parseInt(String(req.query?.limit || '10'), 10) || 10));
+        const decisions = await WorkspaceDecision.find({ roomId: req.params.id })
+            .sort({ createdAt: -1 })
+            .limit(limit)
+            .lean();
+        const decisionIds = decisions.map((decision) => decision._id);
+        const tasks = await WorkspaceTask.find({
+            roomId: req.params.id,
+            $or: [
+                { decisionId: { $in: decisionIds } },
+                { decisionId: null },
+            ],
+        })
+            .sort({ createdAt: -1 })
+            .limit(limit * 5)
+            .lean();
+
+        const generatedAt = new Date();
+        const markdown = formatDecisionPackMarkdown({
+            room,
+            decisions,
+            tasks,
+            generatedAt,
+        });
+
+        res.json({
+            pack: {
+                generatedAt,
+                roomId: req.params.id,
+                roomName: room.name,
+                decisionCount: decisions.length,
+                taskCount: tasks.length,
+                markdown,
+            },
+            decisions: decisions.map((decision) => workspaceDecisionSummary(decision)),
+            tasks: tasks.map((task) => workspaceTaskSummary(task)),
         });
     } catch (err) {
         next(err);

--- a/backend/test/decision.pack.test.js
+++ b/backend/test/decision.pack.test.js
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import mongoose from 'mongoose';
+
+process.env.NODE_ENV = 'test';
+const { createApp } = await import('../src/index.js');
+
+const Room = (await import('../src/models/Room.js')).default;
+const WorkspaceDecision = (await import('../src/models/WorkspaceDecision.js')).default;
+const WorkspaceTask = (await import('../src/models/WorkspaceTask.js')).default;
+
+const originalReadyStateDescriptor = Object.getOwnPropertyDescriptor(mongoose.connection, 'readyState');
+
+function forceMongoReady() {
+  Object.defineProperty(mongoose.connection, 'readyState', { configurable: true, enumerable: true, get: () => 1 });
+}
+
+function restoreMongoReady() {
+  if (originalReadyStateDescriptor) {
+    Object.defineProperty(mongoose.connection, 'readyState', originalReadyStateDescriptor);
+  }
+}
+
+function withStub(object, key, impl) {
+  const previous = object[key];
+  object[key] = impl;
+  return () => {
+    object[key] = previous;
+  };
+}
+
+function buildChain(items) {
+  return {
+    sort() { return this; },
+    limit() { return this; },
+    lean: async () => items,
+  };
+}
+
+async function requestJson({ port, path, method = 'GET', headers = {} }) {
+  return await new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, path, method, headers }, (res) => {
+      let data = '';
+      res.setEncoding('utf8');
+      res.on('data', (c) => { data += c; });
+      res.on('end', () => resolve({ status: res.statusCode, data }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+await test('GET decision-pack returns markdown payload', async (t) => {
+  forceMongoReady();
+  t.after(() => restoreMongoReady());
+
+  const fakeRoomId = '507f191e810c19729de860aa';
+  const fakeUserId = 'user_pack_1';
+
+  const restoreFindRoom = withStub(Room, 'findById', async () => ({
+    _id: fakeRoomId,
+    name: 'Growth Team',
+    members: [{ userId: fakeUserId, role: 'owner' }],
+  }));
+  const restoreFindDecisions = withStub(WorkspaceDecision, 'find', () => buildChain([
+    { _id: 'd1', roomId: fakeRoomId, title: 'Launch pilot', summary: 'Start with 5 design partners.' },
+  ]));
+  const restoreFindTasks = withStub(WorkspaceTask, 'find', () => buildChain([
+    { _id: 't1', roomId: fakeRoomId, decisionId: 'd1', title: 'Prepare outreach list', ownerName: 'Lina' },
+  ]));
+
+  t.after(() => {
+    restoreFindRoom();
+    restoreFindDecisions();
+    restoreFindTasks();
+  });
+
+  const app = createApp();
+  const server = app.listen(0);
+  t.after(() => server.close());
+  await new Promise((r) => server.once('listening', r));
+  const port = server.address().port;
+
+  const res = await requestJson({
+    port,
+    path: `/api/rooms/${fakeRoomId}/decision-pack`,
+    headers: { 'x-user-id': fakeUserId, 'x-display-name': 'Lina' },
+  });
+
+  assert.equal(res.status, 200);
+  const json = JSON.parse(res.data);
+  assert.equal(json.pack.roomName, 'Growth Team');
+  assert.match(json.pack.markdown, /Decision Pack/);
+  assert.match(json.pack.markdown, /Launch pilot/);
+});

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -33,6 +33,16 @@ Scoring guidance used for ordering:
 - `Effort` (1-5): implementation complexity
 - Priority score = `(Impact * Urgency) / Effort`
 
+### KPI Impact Requirement (new)
+
+Every new backlog item must declare:
+
+- Primary KPI impacted (one of: activation rate, useful-answer rate, export rate, D7 retention, API reliability)
+- Expected directional effect (e.g. `+10% export rate`, `-15% retry rate`)
+- Time-to-impact expectation (`<2 weeks`, `2-6 weeks`, `>6 weeks`)
+
+This rule prevents feature sprawl and keeps planning tied to business outcomes.
+
 ## Phase Plan (Roadmap)
 
 ### Phase A - Stabilization and Operational Sign-off (Now)

--- a/docs/strategic_execution_plan_q2_2026.md
+++ b/docs/strategic_execution_plan_q2_2026.md
@@ -1,0 +1,57 @@
+# Strategic Execution Plan — Q2 2026
+
+Last updated: 2026-04-29
+
+## Strategic Goal
+
+Make Hackit indispensable for teams by turning channel conversations into executable, traceable decisions.
+
+## Product Wedge (focus segment)
+
+Primary segment for Q2: product and growth teams in SMB/scale-up environments.
+
+Why this wedge:
+- frequent cross-functional decisions,
+- high coordination cost,
+- immediate value from structured decisions + export.
+
+## Core JTBD
+
+"As a team, we want to turn discussion into a decision and assigned actions in under 30 minutes."
+
+## Value Track Priorities
+
+1. Decision Pack workflow (discoverable from `/decide`)
+2. Execution export to one destination first (Notion-first)
+3. Trust layer in outputs (confidence + assumptions + limits)
+4. KPI instrumentation dashboard used in weekly product review
+
+## 6-Week Delivery Sequence
+
+### Weeks 1-2
+- Close operational sign-off items (BL-002/BL-003)
+- Release KPI dashboard MVP (BL-007)
+- Start Decision Pack API + markdown payload
+
+### Weeks 3-4
+- Add UI entry points for Decision Pack in channel context panel
+- Add Notion export path for Decision Pack
+- Add owner/deadline completeness checks before export
+
+### Weeks 5-6
+- Vertical template pack v2 for product/growth rituals
+- Add adoption analytics: decision-pack open rate, export conversion
+- Run 10 design partner feedback sessions
+
+## KPI Commitments
+
+- Activation: +15% first-week team activation
+- Core value: +20% decision-to-export conversion
+- Engagement: +10% weekly active channels
+- Reliability: keep API 5xx < 1% on search + decision routes
+
+## Guardrails
+
+- No additional connector expansion before Notion Decision Pack flow is stable.
+- Any new feature requires a KPI impact declaration in `docs/backlog.md`.
+- Every weekly release includes one reliability improvement and one user-facing value improvement.


### PR DESCRIPTION
### Motivation

- Provide a machine- and human-friendly "Decision Pack" export for a room to summarize decisions and linked tasks as Markdown and JSON.
- Surface the feature in planning and guardrails by adding related docs and backlog KPI requirements.

### Description

- Add `formatDecisionPackMarkdown` to build a readable Markdown decision pack from room, decisions, and tasks data.
- Add a new route `GET /:id/decision-pack` that validates membership, loads decisions and tasks, and returns a JSON payload containing `pack` metadata and `markdown` along with summarized `decisions` and `tasks` using `workspace*Summary` helpers.
- Introduce `backend/test/decision.pack.test.js` which stubs Mongoose models, spins up the app, and verifies the `decision-pack` response and Markdown content.
- Update `docs/backlog.md` with a new KPI impact requirement and add `docs/strategic_execution_plan_q2_2026.md` describing the Decision Pack priority and roadmap.

### Testing

- Executed the new unit test `backend/test/decision.pack.test.js` which starts the app, stubs model calls, requests `GET /api/rooms/:id/decision-pack`, and validated the `200` response and Markdown contents, and the test passed.
- The test uses a stubbed MongoDB ready-state and model `find` stubs to exercise the route without a real database.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26c2dc5c4832fb45c34af11f55669)