### PR TITLE
Add Decision Pack API and frontend support with markdown formatter and tests

### DIFF
--- a/backend/src/routes/rooms.js
+++ b/backend/src/routes/rooms.js
@@ -210,6 +210,102 @@ function workspaceMilestoneSummary(milestone) {
     };
 }
 
+function formatDecisionPackMarkdown({ room, decisions, tasks, generatedAt, mode = 'checklist' }) {
+    const safeRoomName = String(room?.name || 'Channel').trim() || 'Channel';
+    const lines = [];
+    lines.push(`# Decision Pack — ${safeRoomName}`);
+    lines.push('');
+    lines.push(`Generated at: ${generatedAt.toISOString()}`);
+    lines.push('');
+    lines.push(mode === 'executive' ? '## Executive Decisions' : '## Decisions');
+    lines.push('');
+
+    if (!decisions.length) {
+        lines.push('- No decisions available yet.');
+    } else {
+        decisions.forEach((decision, index) => {
+            const decisionId = String(decision?._id || '').trim();
+            const title = String(decision?.title || '').trim() || `Decision ${index + 1}`;
+            const summary = String(decision?.summary || '').trim();
+            lines.push(`### ${index + 1}. ${title}`);
+            if (summary) lines.push(summary);
+            const linkedTasks = tasks.filter(
+                (task) => String(task?.decisionId || '') === decisionId
+            );
+            if (mode === 'executive') {
+                const owners = linkedTasks
+                    .map((task) => String(task?.ownerName || '').trim())
+                    .filter(Boolean);
+                if (owners.length) {
+                    lines.push(`Owners: ${Array.from(new Set(owners)).join(', ')}`);
+                }
+            } else if (!linkedTasks.length) {
+                lines.push('- Tasks: none linked yet.');
+            } else {
+                lines.push('- Tasks:');
+                linkedTasks.forEach((task) => {
+                    const taskTitle = String(task?.title || '').trim() || 'Untitled task';
+                    const ownerName = String(task?.ownerName || '').trim();
+                    const dueDate = task?.dueDate ? new Date(task.dueDate).toISOString().slice(0, 10) : '';
+                    const suffix = [ownerName ? `owner: ${ownerName}` : '', dueDate ? `due: ${dueDate}` : '']
+                        .filter(Boolean)
+                        .join(', ');
+                    lines.push(`  - ${taskTitle}${suffix ? ` (${suffix})` : ''}`);
+                });
+            }
+            lines.push('');
+        });
+    }
+
+    lines.push(mode === 'executive' ? '## Open Risks / Open Items' : '## Open Tasks (without decision link)');
+    lines.push('');
+    const unlinkedTasks = tasks.filter((task) => !task?.decisionId);
+    if (!unlinkedTasks.length) {
+        lines.push('- None.');
+    } else {
+        unlinkedTasks.forEach((task) => {
+            lines.push(`- ${String(task?.title || 'Untitled task').trim()}`);
+        });
+    }
+    lines.push('');
+    lines.push('## Next Review');
+    lines.push('');
+    lines.push('- Validate owners and deadlines for all critical tasks.');
+    lines.push('- Confirm decision status in the next channel review.');
+    if (mode === 'executive') {
+        lines.push('- Align on expected business impact and decision success criteria.');
+    }
+    return lines.join('\n');
+}
+
+async function loadDecisionPackData(roomId, { limit = 10, includeOpenTasks = true } = {}) {
+    const decisions = await WorkspaceDecision.find({ roomId })
+        .sort({ createdAt: -1 })
+        .limit(limit)
+        .lean();
+    const decisionIds = decisions.map((decision) => decision._id);
+
+    const taskFilter = includeOpenTasks
+        ? {
+            roomId,
+            $or: [
+                { decisionId: { $in: decisionIds } },
+                { decisionId: null },
+            ],
+        }
+        : {
+            roomId,
+            decisionId: { $in: decisionIds },
+        };
+
+    const tasks = await WorkspaceTask.find(taskFilter)
+        .sort({ createdAt: -1 })
+        .limit(limit * 5)
+        .lean();
+
+    return { decisions, tasks };
+}
+
 function extractJsonObject(text) {
     const raw = String(text || '').trim();
     if (!raw) return null;
@@ -1711,6 +1807,128 @@ router.post('/:id/decisions/:decisionId/convert', validateBody(validateConvertDe
             decision: workspaceDecisionSummary(decision),
             tasks: createdTasks.map((task) => workspaceTaskSummary(task)),
         });
+    } catch (err) {
+        next(err);
+    }
+});
+
+router.get('/:id/decision-pack', async (req, res, next) => {
+    try {
+        const room = await loadRoomOr404(req.params.id, res);
+        if (!room) return;
+        if (!isRoomMember(room, req.userId)) {
+            return res.status(403).json({ error: 'Not a member of this room' });
+        }
+
+        const limit = Math.max(1, Math.min(50, Number.parseInt(String(req.query?.limit || '10'), 10) || 10));
+        const mode = String(req.query?.mode || 'checklist').trim().toLowerCase();
+        if (mode !== 'checklist' && mode !== 'executive') {
+            return res.status(400).json({ error: 'Invalid mode. Use checklist or executive.' });
+        }
+        const includeOpenTasks = String(req.query?.includeOpenTasks || 'true')
+            .trim()
+            .toLowerCase() !== 'false';
+        const { decisions, tasks } = await loadDecisionPackData(req.params.id, {
+            limit,
+            includeOpenTasks,
+        });
+
+        const generatedAt = new Date();
+        const markdown = formatDecisionPackMarkdown({
+            room,
+            decisions,
+            tasks,
+            generatedAt,
+            mode,
+        });
+
+        res.json({
+            pack: {
+                generatedAt,
+                roomId: req.params.id,
+                roomName: room.name,
+                decisionCount: decisions.length,
+                taskCount: tasks.length,
+                mode,
+                includeOpenTasks,
+                markdown,
+            },
+            decisions: decisions.map((decision) => workspaceDecisionSummary(decision)),
+            tasks: tasks.map((task) => workspaceTaskSummary(task)),
+        });
+    } catch (err) {
+        next(err);
+    }
+});
+
+router.post('/:id/decision-pack/share', validateBody(validateSharePayload), async (req, res, next) => {
+    try {
+        const room = await loadRoomOr404(req.params.id, res);
+        if (!room) return;
+        if (!isRoomMember(room, req.userId)) {
+            return res.status(403).json({ error: 'Not a member of this room' });
+        }
+
+        const { target, note, idempotencyKey } = req.validatedBody;
+        const connector = getExportConnector(target);
+        if (!connector) {
+            return res.status(400).json({ error: 'Unsupported target' });
+        }
+        if (!connector.isConfigured(room)) {
+            return res.status(412).json({ error: `${connector.target} integration is not configured` });
+        }
+
+        const mode = String(req.query?.mode || 'executive').trim().toLowerCase();
+        if (mode !== 'checklist' && mode !== 'executive') {
+            return res.status(400).json({ error: 'Invalid mode. Use checklist or executive.' });
+        }
+
+        const { decisions, tasks } = await loadDecisionPackData(req.params.id, {
+            limit: 10,
+            includeOpenTasks: mode === 'checklist',
+        });
+        const summary = formatDecisionPackMarkdown({ room, decisions, tasks, generatedAt: new Date(), mode });
+
+        const history = await RoomShareHistory.create({
+            roomId: room._id,
+            artifactId: null,
+            target: connector.target,
+            status: 'pending',
+            idempotencyKey: idempotencyKey || '',
+            actorId: req.userId,
+            actorName: req.displayName,
+            note: note || 'Decision Pack export',
+            summary: summary.slice(0, 1000),
+        });
+
+        try {
+            const outcome = await executeWithRetry(
+                () => connector.send({ room, summary, note: note || 'Decision Pack export' }),
+                { maxAttempts: 3, baseDelayMs: 200 }
+            );
+            history.status = 'success';
+            history.retries = Math.max(0, Number(outcome.attempts || 1) - 1);
+            history.externalId = outcome.result?.externalId || '';
+            history.externalUrl = outcome.result?.externalUrl || '';
+            history.metadata = outcome.result?.metadata || null;
+            await history.save();
+            return res.status(201).json({
+                share: {
+                    id: String(history._id),
+                    target: history.target,
+                    status: history.status,
+                    externalUrl: history.externalUrl,
+                    mode,
+                },
+            });
+        } catch (err) {
+            history.status = 'failed';
+            history.retries = Number(err?.retries || 0);
+            history.errorCode = String(err?.code || err?.status || 'export_failed').slice(0, 120);
+            history.errorMessage = String(err?.message || 'Export failed').slice(0, 3000);
+            await history.save();
+            return res.status(502).json({ error: 'Decision Pack export failed', code: history.errorCode });
+        }
     } catch (err) {
         next(err);
     }

--- a/backend/test/decision.pack.test.js
+++ b/backend/test/decision.pack.test.js
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import mongoose from 'mongoose';
+
+process.env.NODE_ENV = 'test';
+const { createApp } = await import('../src/index.js');
+
+const Room = (await import('../src/models/Room.js')).default;
+const WorkspaceDecision = (await import('../src/models/WorkspaceDecision.js')).default;
+const WorkspaceTask = (await import('../src/models/WorkspaceTask.js')).default;
+
+const originalReadyStateDescriptor = Object.getOwnPropertyDescriptor(mongoose.connection, 'readyState');
+
+function forceMongoReady() { Object.defineProperty(mongoose.connection, 'readyState', { configurable: true, enumerable: true, get: () => 1 }); }
+function restoreMongoReady() { if (originalReadyStateDescriptor) Object.defineProperty(mongoose.connection, 'readyState', originalReadyStateDescriptor); }
+function withStub(object, key, impl) { const previous = object[key]; object[key] = impl; return () => { object[key] = previous; }; }
+function buildChain(items) { return { sort() { return this; }, limit() { return this; }, lean: async () => items }; }
+async function requestJson({ port, path, method = 'GET', headers = {}, body }) {
+  const payload = body ? JSON.stringify(body) : '';
+  return await new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, path, method, headers: { ...headers, ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } : {}) } }, (res) => {
+      let data = ''; res.setEncoding('utf8'); res.on('data', (c) => { data += c; }); res.on('end', () => resolve({ status: res.statusCode, data }));
+    });
+    req.on('error', reject); if (payload) req.write(payload); req.end();
+  });
+}
+
+await test('GET decision-pack supports executive mode', async (t) => {
+  forceMongoReady(); t.after(() => restoreMongoReady());
+  const fakeRoomId = '507f191e810c19729de860aa'; const fakeUserId = 'user_pack_1';
+  const restoreFindRoom = withStub(Room, 'findById', async () => ({ _id: fakeRoomId, name: 'Growth Team', members: [{ userId: fakeUserId, role: 'owner' }] }));
+  const restoreFindDecisions = withStub(WorkspaceDecision, 'find', () => buildChain([{ _id: 'd1', roomId: fakeRoomId, title: 'Launch pilot', summary: 'Start with 5 design partners.' }]));
+  const restoreFindTasks = withStub(WorkspaceTask, 'find', () => buildChain([{ _id: 't1', roomId: fakeRoomId, decisionId: 'd1', title: 'Prepare outreach list', ownerName: 'Lina' }]));
+  t.after(() => { restoreFindRoom(); restoreFindDecisions(); restoreFindTasks(); });
+
+  const app = createApp(); const server = app.listen(0); t.after(() => server.close()); await new Promise((r) => server.once('listening', r)); const port = server.address().port;
+  const res = await requestJson({ port, path: `/api/rooms/${fakeRoomId}/decision-pack?mode=executive`, headers: { 'x-user-id': fakeUserId, 'x-display-name': 'Lina' } });
+  assert.equal(res.status, 200);
+  const json = JSON.parse(res.data);
+  assert.equal(json.pack.mode, 'executive');
+  assert.match(json.pack.markdown, /Executive Decisions/);
+});
+
+await test('GET decision-pack rejects invalid mode', async (t) => {
+  forceMongoReady(); t.after(() => restoreMongoReady());
+  const fakeRoomId = '507f191e810c19729de860ab'; const fakeUserId = 'user_pack_2';
+  const restoreFindRoom = withStub(Room, 'findById', async () => ({ _id: fakeRoomId, name: 'Ops', members: [{ userId: fakeUserId, role: 'owner' }] }));
+  t.after(() => restoreFindRoom());
+  const app = createApp(); const server = app.listen(0); t.after(() => server.close()); await new Promise((r) => server.once('listening', r)); const port = server.address().port;
+  const res = await requestJson({ port, path: `/api/rooms/${fakeRoomId}/decision-pack?mode=foo`, headers: { 'x-user-id': fakeUserId } });
+  assert.equal(res.status, 400);
+});
+
+await test('POST decision-pack/share rejects unsupported target', async (t) => {
+  forceMongoReady(); t.after(() => restoreMongoReady());
+  const fakeRoomId = '507f191e810c19729de860ac'; const fakeUserId = 'user_pack_3';
+  const restoreFindRoom = withStub(Room, 'findById', async () => ({ _id: fakeRoomId, name: 'Ops', members: [{ userId: fakeUserId, role: 'owner' }] }));
+  t.after(() => restoreFindRoom());
+  const app = createApp(); const server = app.listen(0); t.after(() => server.close()); await new Promise((r) => server.once('listening', r)); const port = server.address().port;
+  const res = await requestJson({ port, method: 'POST', path: `/api/rooms/${fakeRoomId}/decision-pack/share`, headers: { 'x-user-id': fakeUserId }, body: { target: 'email', note: 'x' } });
+  assert.equal(res.status, 400);
+});
+
+await test('GET decision-pack can disable open tasks', async (t) => {
+  forceMongoReady(); t.after(() => restoreMongoReady());
+  const fakeRoomId = '507f191e810c19729de860ad'; const fakeUserId = 'user_pack_4';
+  const restoreFindRoom = withStub(Room, 'findById', async () => ({ _id: fakeRoomId, name: 'Ops', members: [{ userId: fakeUserId, role: 'owner' }] }));
+  const restoreFindDecisions = withStub(WorkspaceDecision, 'find', () => buildChain([{ _id: 'd1', roomId: fakeRoomId, title: 'Rollout', summary: '' }]));
+  const restoreFindTasks = withStub(WorkspaceTask, 'find', () => buildChain([{ _id: 't1', roomId: fakeRoomId, decisionId: 'd1', title: 'Task linked' }]));
+  t.after(() => { restoreFindRoom(); restoreFindDecisions(); restoreFindTasks(); });
+  const app = createApp(); const server = app.listen(0); t.after(() => server.close()); await new Promise((r) => server.once('listening', r)); const port = server.address().port;
+  const res = await requestJson({ port, path: `/api/rooms/${fakeRoomId}/decision-pack?includeOpenTasks=false`, headers: { 'x-user-id': fakeUserId } });
+  assert.equal(res.status, 200);
+  const json = JSON.parse(res.data);
+  assert.equal(json.pack.includeOpenTasks, false);
+});
+
+await test('POST decision-pack/share returns 412 when target integration is missing', async (t) => {
+  forceMongoReady(); t.after(() => restoreMongoReady());
+  const fakeRoomId = '507f191e810c19729de860ae'; const fakeUserId = 'user_pack_5';
+  const restoreFindRoom = withStub(Room, 'findById', async () => ({ _id: fakeRoomId, name: 'Ops', members: [{ userId: fakeUserId, role: 'owner' }], integrations: { notion: { enabled: false } } }));
+  t.after(() => restoreFindRoom());
+  const app = createApp(); const server = app.listen(0); t.after(() => server.close()); await new Promise((r) => server.once('listening', r)); const port = server.address().port;
+  const res = await requestJson({ port, method: 'POST', path: `/api/rooms/${fakeRoomId}/decision-pack/share?mode=checklist`, headers: { 'x-user-id': fakeUserId }, body: { target: 'notion', note: 'x' } });
+  assert.equal(res.status, 412);
+});

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -33,6 +33,16 @@ Scoring guidance used for ordering:
 - `Effort` (1-5): implementation complexity
 - Priority score = `(Impact * Urgency) / Effort`
 
+### KPI Impact Requirement (new)
+
+Every new backlog item must declare:
+
+- Primary KPI impacted (one of: activation rate, useful-answer rate, export rate, D7 retention, API reliability)
+- Expected directional effect (e.g. `+10% export rate`, `-15% retry rate`)
+- Time-to-impact expectation (`<2 weeks`, `2-6 weeks`, `>6 weeks`)
+
+This rule prevents feature sprawl and keeps planning tied to business outcomes.
+
 ## Phase Plan (Roadmap)
 
 ### Phase A - Stabilization and Operational Sign-off (Now)

--- a/docs/strategic_execution_plan_q2_2026.md
+++ b/docs/strategic_execution_plan_q2_2026.md
@@ -1,0 +1,57 @@
+# Strategic Execution Plan — Q2 2026
+
+Last updated: 2026-04-29
+
+## Strategic Goal
+
+Make Hackit indispensable for teams by turning channel conversations into executable, traceable decisions.
+
+## Product Wedge (focus segment)
+
+Primary segment for Q2: product and growth teams in SMB/scale-up environments.
+
+Why this wedge:
+- frequent cross-functional decisions,
+- high coordination cost,
+- immediate value from structured decisions + export.
+
+## Core JTBD
+
+"As a team, we want to turn discussion into a decision and assigned actions in under 30 minutes."
+
+## Value Track Priorities
+
+1. Decision Pack workflow (discoverable from `/decide`)
+2. Execution export to one destination first (Notion-first)
+3. Trust layer in outputs (confidence + assumptions + limits)
+4. KPI instrumentation dashboard used in weekly product review
+
+## 6-Week Delivery Sequence
+
+### Weeks 1-2
+- Close operational sign-off items (BL-002/BL-003)
+- Release KPI dashboard MVP (BL-007)
+- Start Decision Pack API + markdown payload
+
+### Weeks 3-4
+- Add UI entry points for Decision Pack in channel context panel
+- Add Notion export path for Decision Pack
+- Add owner/deadline completeness checks before export
+
+### Weeks 5-6
+- Vertical template pack v2 for product/growth rituals
+- Add adoption analytics: decision-pack open rate, export conversion
+- Run 10 design partner feedback sessions
+
+## KPI Commitments
+
+- Activation: +15% first-week team activation
+- Core value: +20% decision-to-export conversion
+- Engagement: +10% weekly active channels
+- Reliability: keep API 5xx < 1% on search + decision routes
+
+## Guardrails
+
+- No additional connector expansion before Notion Decision Pack flow is stable.
+- Any new feature requires a KPI impact declaration in `docs/backlog.md`.
+- Every weekly release includes one reliability improvement and one user-facing value improvement.

--- a/frontend_flutter/lib/models/room.dart
+++ b/frontend_flutter/lib/models/room.dart
@@ -432,6 +432,68 @@ class WorkspaceTask {
       );
 }
 
+class DecisionPackPayload {
+  final DateTime generatedAt;
+  final String roomId;
+  final String roomName;
+  final int decisionCount;
+  final int taskCount;
+  final String mode;
+  final bool includeOpenTasks;
+  final String markdown;
+
+  const DecisionPackPayload({
+    required this.generatedAt,
+    required this.roomId,
+    required this.roomName,
+    required this.decisionCount,
+    required this.taskCount,
+    required this.mode,
+    required this.includeOpenTasks,
+    required this.markdown,
+  });
+
+  factory DecisionPackPayload.fromJson(Map<String, dynamic> j) =>
+      DecisionPackPayload(
+        generatedAt: DateTime.tryParse(j['generatedAt']?.toString() ?? '') ??
+            DateTime.now(),
+        roomId: j['roomId']?.toString() ?? '',
+        roomName: j['roomName']?.toString() ?? '',
+        decisionCount: (j['decisionCount'] as num?)?.toInt() ?? 0,
+        taskCount: (j['taskCount'] as num?)?.toInt() ?? 0,
+        mode: j['mode']?.toString() ?? 'checklist',
+        includeOpenTasks: j['includeOpenTasks'] != false,
+        markdown: j['markdown']?.toString() ?? '',
+      );
+}
+
+class DecisionPackResult {
+  final DecisionPackPayload pack;
+  final List<WorkspaceDecision> decisions;
+  final List<WorkspaceTask> tasks;
+
+  const DecisionPackResult({
+    required this.pack,
+    required this.decisions,
+    required this.tasks,
+  });
+
+  factory DecisionPackResult.fromJson(Map<String, dynamic> j) =>
+      DecisionPackResult(
+        pack: DecisionPackPayload.fromJson(
+            (j['pack'] as Map?)?.cast<String, dynamic>() ?? const {}),
+        decisions: (j['decisions'] as List? ?? [])
+            .whereType<Map>()
+            .map((item) =>
+                WorkspaceDecision.fromJson(item.cast<String, dynamic>()))
+            .toList(),
+        tasks: (j['tasks'] as List? ?? [])
+            .whereType<Map>()
+            .map((item) => WorkspaceTask.fromJson(item.cast<String, dynamic>()))
+            .toList(),
+      );
+}
+
 class ExtractedTaskDraft {
   final String title;
   final String description;

--- a/frontend_flutter/lib/providers/room_provider.dart
+++ b/frontend_flutter/lib/providers/room_provider.dart
@@ -152,6 +152,8 @@ class RoomProvider extends ChangeNotifier {
   List<WorkspaceDecision> decisions = [];
   List<WorkspaceTask> tasks = [];
   List<RoomShareHistoryItem> shareHistory = [];
+  DecisionPackResult? decisionPack;
+  bool loadingDecisionPack = false;
   RoomIntegrationStatus? slackIntegration;
   RoomIntegrationStatus? notionIntegration;
   bool loadingNotionPages = false;
@@ -1162,6 +1164,62 @@ class RoomProvider extends ChangeNotifier {
     }
   }
 
+  Future<bool> loadDecisionPack({
+    String mode = 'checklist',
+    bool includeOpenTasks = true,
+    int limit = 10,
+  }) async {
+    final room = currentRoom;
+    if (room == null) return false;
+    actionError = null;
+    loadingDecisionPack = true;
+    notifyListeners();
+    try {
+      decisionPack = await _svc.getDecisionPack(
+        room.id,
+        mode: mode,
+        includeOpenTasks: includeOpenTasks,
+        limit: limit,
+      );
+      return true;
+    } catch (e) {
+      actionError = _errorMessage(e);
+      return false;
+    } finally {
+      loadingDecisionPack = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> shareDecisionPack({
+    required String target,
+    String mode = 'executive',
+    String note = '',
+  }) async {
+    final room = currentRoom;
+    if (room == null) return false;
+    actionError = null;
+    notifyListeners();
+    try {
+      await _svc.shareDecisionPack(
+        room.id,
+        target: target,
+        mode: mode,
+        note: note,
+      );
+      unawaited(AnalyticsManager().logFeatureUsed(
+        feature: 'decision_pack_shared',
+        parameters: {'target': target, 'mode': mode},
+      ));
+      await refreshShareHistory(limit: 12);
+      return true;
+    } catch (e) {
+      actionError = _errorMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
   // ── Invite link ────────────────────────────────────────────────────────────────
 
   Future<String?> getInviteLink() async {
@@ -1192,10 +1250,12 @@ class RoomProvider extends ChangeNotifier {
     decisions = [];
     tasks = [];
     shareHistory = [];
+    decisionPack = null;
     slackIntegration = null;
     notionIntegration = null;
     loadingNotionPages = false;
     loadingShareHistory = false;
+    loadingDecisionPack = false;
     loadingIntegrations = false;
     aiThinking = false;
     wsReconnecting = false;

--- a/frontend_flutter/lib/services/room_service.dart
+++ b/frontend_flutter/lib/services/room_service.dart
@@ -638,6 +638,46 @@ class RoomService {
         .toList();
   }
 
+  Future<DecisionPackResult> getDecisionPack(
+    String roomId, {
+    String mode = 'checklist',
+    bool includeOpenTasks = true,
+    int limit = 10,
+  }) async {
+    final qp = <String, String>{
+      'mode': mode,
+      'includeOpenTasks': includeOpenTasks ? 'true' : 'false',
+      'limit': '${limit.clamp(1, 50)}',
+    };
+    final uri = Uri.parse('$_base/api/rooms/$roomId/decision-pack')
+        .replace(queryParameters: qp);
+    final r = await _http
+        .get(uri, headers: await _headers())
+        .timeout(const Duration(seconds: 20));
+    return DecisionPackResult.fromJson(_parse(r));
+  }
+
+  Future<void> shareDecisionPack(
+    String roomId, {
+    required String target,
+    String mode = 'executive',
+    String note = '',
+  }) async {
+    final uri = Uri.parse('$_base/api/rooms/$roomId/decision-pack/share')
+        .replace(queryParameters: {'mode': mode});
+    final res = await _http
+        .post(
+          uri,
+          headers: await _headers(),
+          body: jsonEncode({
+            'target': target,
+            if (note.trim().isNotEmpty) 'note': note.trim(),
+          }),
+        )
+        .timeout(const Duration(seconds: 20));
+    _parse(res);
+  }
+
   // ── WebSocket (per room) ──────────────────────────────────────────────────────
 
   final Map<String, WebSocketChannel> _channels = {};


### PR DESCRIPTION
### Motivation

- Provide a consumable "Decision Pack" export of recent decisions and related tasks for channels to support execution and review workflows.
- Support two output modes (`checklist` and `executive`) and the ability to share the pack to configured integrations. 
- Surface the Decision Pack to the frontend so UI can request, display, and share the payload.

### Description

- Added backend helpers `formatDecisionPackMarkdown` and `loadDecisionPackData` plus two endpoints `GET /api/rooms/:id/decision-pack` and `POST /api/rooms/:id/decision-pack/share` to produce and share markdown decision packs. 
- Implemented export sharing flow with integration checks, idempotency history via `RoomShareHistory`, retry wrapper, and structured JSON response containing `pack`, `decisions`, and `tasks`. 
- Added comprehensive unit tests in `backend/test/decision.pack.test.js` that stub DB calls and validate modes, query flags, and share validation. 
- Extended the Flutter client with `DecisionPackPayload`, `DecisionPackResult`, provider methods `loadDecisionPack` and `shareDecisionPack`, and service methods `getDecisionPack` and `shareDecisionPack` to fetch and post pack data. 
- Updated backlog docs and added a strategic execution plan document to reflect Decision Pack priority and KPI requirements.

### Testing

- Ran the new backend unit tests in `backend/test/decision.pack.test.js` (via `node --test`) and they passed. 
- Exercised the new `GET /api/rooms/:id/decision-pack` endpoint in tests for `executive` and invalid `mode` handling and confirmed expected HTTP status and payload shape. 
- Exercised the `POST /api/rooms/:id/decision-pack/share` flow in tests to validate unsupported targets and missing integration checks and confirmed expected error responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26c2dc5c4832fb45c34af11f55669)